### PR TITLE
Upgrade PHP to version 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,43 +9,39 @@ FROM nginx
 ################################################################################
 
 # Remove default nginx configs.
-RUN rm -f /etc/nginx/conf.d/*
-
 # Install packages
-RUN apt-get update && apt-get install -my \
-  supervisor \
-  curl \
-  wget \
-  php5-curl \
-  php5-fpm \
-  php5-gd \
-  php5-memcached \
-  php5-mysql \
-  php5-mcrypt \
-  php5-sqlite \
-  php5-xdebug \
-  php-apc
-
-# Ensure that PHP5 FPM is run as root.
-RUN sed -i "s/user = www-data/user = root/" /etc/php5/fpm/pool.d/www.conf
-RUN sed -i "s/group = www-data/group = root/" /etc/php5/fpm/pool.d/www.conf
-
-# Pass all docker environment
-RUN sed -i '/^;clear_env = no/s/^;//' /etc/php5/fpm/pool.d/www.conf
-
-# Get access to FPM-ping page /ping
-RUN sed -i '/^;ping\.path/s/^;//' /etc/php5/fpm/pool.d/www.conf
-# Get access to FPM_Status page /status
-RUN sed -i '/^;pm\.status_path/s/^;//' /etc/php5/fpm/pool.d/www.conf
-
-# Prevent PHP Warning: 'xdebug' already loaded.
-# XDebug loaded with the core
-RUN sed -i '/.*xdebug.so$/s/^/;/' /etc/php5/mods-available/xdebug.ini
+RUN rm -f /etc/nginx/conf.d/* \
+  && mkdir -p /run/php /run/hhvm \
+  && apt-get update && apt-get upgrade -y && apt-get install -my \
+    supervisor \
+    curl \
+    wget \
+    php-curl \
+    php-fpm \
+    php-gd \
+    php-memcached \
+    php-mysql \
+    php-mcrypt \
+    php-sqlite3 \
+    php-xdebug \
+    php-apcu
 
 # Install HHVM
-RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449
-RUN echo deb http://dl.hhvm.com/debian jessie main | tee /etc/apt/sources.list.d/hhvm.list
-RUN apt-get update && apt-get install -y hhvm
+RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list \
+    && apt-get update && apt-get install -y hhvm
+
+# Ensure that PHP5 FPM is run as root.
+# Pass all docker environment
+# Get access to FPM-ping page /ping
+# Get access to FPM_Status page /status
+# Prevent PHP Warning: 'xdebug' already loaded.
+# XDebug loaded with the core
+RUN sed -i "s/user = www-data/user = root/" /etc/php/7.0/fpm/pool.d/www.conf \
+    && sed -i "s/group = www-data/group = root/" /etc/php/7.0/fpm/pool.d/www.conf \
+    && sed -i '/^;clear_env = no/s/^;//' /etc/php/7.0/fpm/pool.d/www.conf \
+    && sed -i '/^;ping\.path/s/^;//' /etc/php/7.0/fpm/pool.d/www.conf \
+    && sed -i '/^;pm\.status_path/s/^;//' /etc/php/7.0/fpm/pool.d/www.conf \
+    && sed -i '/.*xdebug.so$/s/^/;/' /etc/php/7.0/mods-available/xdebug.ini
 
 # Add configuration files
 COPY conf/nginx.conf /etc/nginx/

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -6,12 +6,12 @@ command = /usr/sbin/nginx
 user = root
 autostart = true
 
-[program:php5-fpm]
-command = /usr/sbin/php5-fpm -FR
+[program:php-fpm]
+command = /usr/sbin/php-fpm7.0 -FR
 user = root
 autostart = true
 
 [program:hhvm-fastcgi]
-command = hhvm --mode server -vServer.Type=fastcgi -vServer.FileSocket=/var/run/hhvm/hhvm.sock
+command = hhvm --mode server -vServer.Type=fastcgi -vServer.AllowRunAsRoot=1 -vServer.FileSocket=/var/run/hhvm/hhvm.sock
 user = root
 autostart = true

--- a/sites/default.vhost
+++ b/sites/default.vhost
@@ -38,7 +38,7 @@ server {
     include       fastcgi_params;
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    #fastcgi_pass  unix:/var/run/php/php7.0-fpm.sock;
-    fastcgi_pass  unix:/var/run/hhvm/hhvm.sock;
+    fastcgi_pass  unix:/var/run/php/php7.0-fpm.sock;
+    # fastcgi_pass  unix:/var/run/hhvm/hhvm.sock;
   }
 }

--- a/sites/default.vhost
+++ b/sites/default.vhost
@@ -16,7 +16,7 @@ server {
      deny all;
      include /etc/nginx/fastcgi_params;
      fastcgi_param SCRIPT_FILENAME /status;
-     fastcgi_pass unix:/var/run/php5-fpm.sock;
+     fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
   }
 
   location /ping {
@@ -24,7 +24,7 @@ server {
      allow all;
      include fastcgi_params;
      fastcgi_param SCRIPT_FILENAME /ping;
-     fastcgi_pass unix:/var/run/php5-fpm.sock;
+     fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
   }
 
   location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
@@ -38,7 +38,7 @@ server {
     include       fastcgi_params;
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_pass  unix:/var/run/php5-fpm.sock;
-    # fastcgi_pass  unix:/var/run/hhvm/hhvm.sock;
+    #fastcgi_pass  unix:/var/run/php/php7.0-fpm.sock;
+    fastcgi_pass  unix:/var/run/hhvm/hhvm.sock;
   }
 }


### PR DESCRIPTION
There is no PHP5 on Debian 9 (stretch) repos.
**Please ensure that all your sites can run it before update**.
Issues: #55 #54 should close.